### PR TITLE
Added checking if provided arguments are objects

### DIFF
--- a/ModelFactoryCollection/ModelFactoryCollection.php
+++ b/ModelFactoryCollection/ModelFactoryCollection.php
@@ -81,7 +81,7 @@ class ModelFactoryCollection implements ModelFactoryCollectionInterface
             $modelFactory = $this->findSupportingModelFactoryForObject($object);
             if (!$modelFactory instanceof ModelFactoryInterface) {
                 throw new ModelFactoryCollectionException(sprintf(
-                    'Model factory for class \'%s\' not found.',
+                    'Model factory for class %s not found.',
                     get_class($object)
                 ));
             }

--- a/ModelFactoryCollection/ModelFactoryCollection.php
+++ b/ModelFactoryCollection/ModelFactoryCollection.php
@@ -78,12 +78,12 @@ class ModelFactoryCollection implements ModelFactoryCollectionInterface
                         'Model factory for class %s not found.',
                         get_class($object)
                     ));
-                } else {
-                    throw new ModelFactoryCollectionException(sprintf(
-                        'Model factory for type %s not found.',
-                        gettype($object)
-                    ));
                 }
+                
+                throw new ModelFactoryCollectionException(sprintf(
+                    'Model factory for type %s not found.',
+                    gettype($object)
+                ));
             }
             $models[$key] = $this->createModelAndSetDependencies($modelFactory, $object);
         }

--- a/ModelFactoryCollection/ModelFactoryCollection.php
+++ b/ModelFactoryCollection/ModelFactoryCollection.php
@@ -71,10 +71,17 @@ class ModelFactoryCollection implements ModelFactoryCollectionInterface
         // If that fails, try to find model factory for each item individually.
         $models = [];
         foreach ($objects as $key => $object) {
+            if (!is_object($object)) {
+                throw new ModelFactoryCollectionException(sprintf(
+                    'Object expected, %s given.',
+                    gettype($object)
+                ));
+            }
+
             $modelFactory = $this->findSupportingModelFactoryForObject($object);
             if (!$modelFactory instanceof ModelFactoryInterface) {
                 throw new ModelFactoryCollectionException(sprintf(
-                    "Model factory for class '%s' not found.",
+                    'Model factory for class \'%s\' not found.',
                     get_class($object)
                 ));
             }

--- a/ModelFactoryCollection/ModelFactoryCollection.php
+++ b/ModelFactoryCollection/ModelFactoryCollection.php
@@ -71,19 +71,19 @@ class ModelFactoryCollection implements ModelFactoryCollectionInterface
         // If that fails, try to find model factory for each item individually.
         $models = [];
         foreach ($objects as $key => $object) {
-            if (!is_object($object)) {
-                throw new ModelFactoryCollectionException(sprintf(
-                    'Object expected, %s given.',
-                    gettype($object)
-                ));
-            }
-
             $modelFactory = $this->findSupportingModelFactoryForObject($object);
             if (!$modelFactory instanceof ModelFactoryInterface) {
-                throw new ModelFactoryCollectionException(sprintf(
-                    'Model factory for class %s not found.',
-                    get_class($object)
-                ));
+                if (is_object($object)) {
+                    throw new ModelFactoryCollectionException(sprintf(
+                        'Model factory for class %s not found.',
+                        get_class($object)
+                    ));
+                } else {
+                    throw new ModelFactoryCollectionException(sprintf(
+                        'Model factory for type %s not found.',
+                        gettype($object)
+                    ));
+                }
             }
             $models[$key] = $this->createModelAndSetDependencies($modelFactory, $object);
         }

--- a/Tests/Functional/ModelFactoryCollectionTest.php
+++ b/Tests/Functional/ModelFactoryCollectionTest.php
@@ -167,6 +167,7 @@ class ModelFactoryCollectionTest extends PHPUnit_Framework_TestCase
             [3],
             [false],
             [new stdClass()],
+            [null],
         ];
     }
 
@@ -186,7 +187,7 @@ class ModelFactoryCollectionTest extends PHPUnit_Framework_TestCase
                 new BarModelFactory()
             );
 
-        $modelFactoryCollection->createModels($invalidArgument);
+        $modelFactoryCollection->createModels([$invalidArgument]);
     }
 
     /**


### PR DESCRIPTION
Fixes #5 - providing an  `array` containing a non-object to `createModels` throws a `ModelFactoryCollectionException` with an appropriate description.
