### PR TITLE
Fixed documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ class FooModelFactory extends ModelFactory
     /**
      * {@inheritdoc}
      */
-    public function supports($object)
+    public function supportsObject($object)
     {
         return ($object instanceof Foo);
     }
@@ -177,7 +177,7 @@ class BazModelFactory extends ModelFactory
     /**
      * {@inheritdoc}
      */
-    public function supports($object)
+    public function supportsObject($object)
     {
         return ($object instanceof Baz);
     }


### PR DESCRIPTION
Hello,

I really like this bundle, thank you for it :)
I found an issue in the documentation.
`ModelFactoryInterface` requires implemented `public function supportsObject($object);` but in the examples we have implemented `public function supports($object)` (`supports` is not used anywhere).

Regards.