### PR TITLE
Symfony 4.1 compatibility

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -17,6 +17,9 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        return new TreeBuilder();
+        $treeBuilder = new TreeBuilder();
+        $treeBuilder->root('xsolve_model_factory');
+
+        return $treeBuilder;
     }
 }


### PR DESCRIPTION
In Symfony 4.1, root node has to be declared